### PR TITLE
Format title sections

### DIFF
--- a/lib/ex_wikipedia/page/page.ex
+++ b/lib/ex_wikipedia/page/page.ex
@@ -37,7 +37,8 @@ defmodule ExWikipedia.Page do
           summary: binary(),
           title: binary(),
           url: binary(),
-          is_redirect?: boolean()
+          is_redirect?: boolean(),
+          links: [String.t()]
         }
 
   @enforce_keys [:content, :page_id, :summary, :title, :url]
@@ -51,7 +52,8 @@ defmodule ExWikipedia.Page do
             summary: "",
             title: "",
             url: "",
-            is_redirect?: false
+            is_redirect?: false,
+            links: []
 
   @doc """
   Fetches a Wikipedia page by its ID.

--- a/test/ex_wikipedia/page/page_parse_test.exs
+++ b/test/ex_wikipedia/page/page_parse_test.exs
@@ -13,9 +13,10 @@ defmodule ExWikipedia.PageParserTest do
       assert {:ok,
               %{
                 categories: [
-                  "Webarchive template wayback links",
-                  "All articles with dead external links",
-                  "Articles with dead external links from June 2016" | _
+                  "1990s black comedy films",
+                  "1990s crime comedy-drama films",
+                  "1994 comedy films"
+                  | _
                 ],
                 content: "Pulp Fiction is a 1994 American black comedy crime film" <> _,
                 external_links: [


### PR DESCRIPTION
- adds styling for sections with the `=` corresponding to the `<h>` tag. e.g. `<h2>` tag will be given `==` as seen in `== Plot ==`
- returns wikipedia's `links` in a struct.
- parsed links inside html are unique