### PR TITLE
splits build_url between find by page and find by id, updates test

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```elixir
-iex> ExWikipedia.page(54173, by: :page_id)
+iex> ExWikipedia.page(54173)
 {:ok,
  %ExWikipedia.Page{
    categories: ["Webarchive template wayback links",
@@ -26,7 +26,7 @@ iex> ExWikipedia.page(54173, by: :page_id)
 ```
 
 ```elixir
-iex> ExWikipedia.page("Pulp Fiction", by: :title)
+iex> ExWikipedia.page("Pulp_Fiction")
 {:ok,
  %ExWikipedia.Page{
    categories: ["Webarchive template wayback links",

--- a/lib/ex_wikipedia.ex
+++ b/lib/ex_wikipedia.ex
@@ -37,7 +37,7 @@ defmodule ExWikipedia do
       {:error, "There is no page with ID 1."}
 
       iex> ExWikipedia.page(%{})
-      {:error, "The Wikipedia ID supplied is not valid."}
+      {:error, "%{} is not supported type for lookup."}
 
   Redirects are allowed by default. Compare the following two results.
 

--- a/lib/ex_wikipedia/page/page.ex
+++ b/lib/ex_wikipedia/page/page.ex
@@ -149,6 +149,10 @@ defmodule ExWikipedia.Page do
      |> URI.encode()}
   end
 
+  defp build_url(id_value, _lang) when not is_binary(id_value) and not is_integer(id_value) do
+    {:error, "#{inspect(id_value)} is not supported type for lookup."}
+  end
+
   defp build_url(_, lang) do
     {:error, "Unsupported language identifier #{inspect(lang)}; language codes must be a string."}
   end

--- a/lib/ex_wikipedia/page/page.ex
+++ b/lib/ex_wikipedia/page/page.ex
@@ -7,9 +7,7 @@ defmodule ExWikipedia.Page do
   @behaviour ExWikipedia
 
   @allow_redirect true
-  @allowed_id_keys [:page, :pageid]
   @default_body_key :body
-  @default_by :pageid
   @default_http_client HTTPoison
   @default_lang "en"
   @default_json_parser Jason
@@ -78,7 +76,6 @@ defmodule ExWikipedia.Page do
        page constitutes a valid response. Default: `#{inspect(@allow_redirect)}`
     - `:language`: Identifies a specific Wikipedia instance to search. You can use the
       `:default_language` config option to set this value. Default: `#{@default_lang}`
-    - `:by`: The field used to identify the page. `#{inspect(@allowed_id_keys)}`. Default: `#{@default_by}`
 
   """
   @impl ExWikipedia
@@ -108,14 +105,12 @@ defmodule ExWikipedia.Page do
         Application.get_env(:ex_wikipedia, :default_language, @default_lang)
       )
 
-    id_key = Keyword.get(opts, :by, @default_by)
-
     parser_opts =
       opts
       |> Keyword.get(:parser_opts, [])
       |> Keyword.put(:allow_redirect, allow_redirect)
 
-    with {:ok, url} <- build_url(id_key, id, language),
+    with {:ok, url} <- build_url(id, language),
          {:ok, raw_response} <- http_client.get(url, http_headers, http_opts),
          :ok <- ok_http_status_code(raw_response, status_key),
          {:ok, body} <- get_body(raw_response, body_key),
@@ -142,18 +137,19 @@ defmodule ExWikipedia.Page do
     end
   end
 
-  defp build_url(id_key, id_value, <<lang::binary-size(2)>>) when id_key in @allowed_id_keys do
+  defp build_url(id_value, lang) when is_binary(lang) and is_binary(id_value) do
     {:ok,
-     "https://#{lang}.wikipedia.org/w/api.php?action=parse&#{id_key}=#{id_value}&format=json&redirects=true&prop=text|langlinks|categories|links|templates|images|externallinks|sections|revid|displaytitle|iwlinks|properties|parsewarnings|headhtml"
+     "https://#{lang}.wikipedia.org/w/api.php?action=parse&page=#{id_value}&format=json&redirects=true&prop=text|langlinks|categories|links|templates|images|externallinks|sections|revid|displaytitle|iwlinks|properties|parsewarnings|headhtml"
      |> URI.encode()}
   end
 
-  defp build_url(id_key, _, lang) when id_key in @allowed_id_keys do
-    {:error,
-     "Unsupported language identifier #{inspect(lang)}; language codes must be 2 characters"}
+  defp build_url(id_value, lang) when is_binary(lang) and is_integer(id_value) do
+    {:ok,
+     "https://#{lang}.wikipedia.org/w/api.php?action=parse&pageid=#{id_value}&format=json&redirects=true&prop=text|langlinks|categories|links|templates|images|externallinks|sections|revid|displaytitle|iwlinks|properties|parsewarnings|headhtml"
+     |> URI.encode()}
   end
 
-  defp build_url(id_key, _, _) when id_key not in @allowed_id_keys do
-    {:error, "Unsupported :by field #{inspect(id_key)}"}
+  defp build_url(_, lang) do
+    {:error, "Unsupported language identifier #{inspect(lang)}; language codes must be a string."}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExWikipedia.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
 
   def project do
     [

--- a/test/ex_wikipedia/page/page_test.exs
+++ b/test/ex_wikipedia/page/page_test.exs
@@ -70,9 +70,9 @@ defmodule ExWikipedia.Page.PageTest do
               }} = Page.fetch("12345", http_client: http_client)
     end
 
-    test ":error when :by not in allowed fields" do
-      assert {:error, _} = Page.fetch("12345", by: :bad_field)
-    end
+    # test ":error when :by not in allowed fields" do
+    #   assert {:error, _} = Page.fetch("12345", by: :bad_field)
+    # end
 
     test ":error when language code not 2 characters" do
       assert {:error, _} = Page.fetch(12_345, language: "too-long")
@@ -88,9 +88,9 @@ defmodule ExWikipedia.Page.PageTest do
       assert {:error, _} = Page.fetch(12_345, http_client: http_client)
     end
 
-    test ":error when non integer id is supplied" do
-      assert {:error, _} = Page.fetch("blah", [])
-    end
+    # test ":error when non integer id is supplied" do
+    #   assert {:error, _} = Page.fetch("blah", [])
+    # end
 
     test ":error when unable to find body key" do
       http_client =
@@ -104,6 +104,10 @@ defmodule ExWikipedia.Page.PageTest do
         end)
 
       assert {:error, _} = Page.fetch(12_345, http_client: http_client, body_key: :payload)
+    end
+
+    test ":error on unsupported languages" do
+      assert {:error, _} = Page.fetch(12_345, language: 123)
     end
   end
 end

--- a/test/ex_wikipedia/page/page_test.exs
+++ b/test/ex_wikipedia/page/page_test.exs
@@ -70,10 +70,6 @@ defmodule ExWikipedia.Page.PageTest do
               }} = Page.fetch("12345", http_client: http_client)
     end
 
-    # test ":error when :by not in allowed fields" do
-    #   assert {:error, _} = Page.fetch("12345", by: :bad_field)
-    # end
-
     test ":error when language code not 2 characters" do
       assert {:error, _} = Page.fetch(12_345, language: "too-long")
     end
@@ -87,10 +83,6 @@ defmodule ExWikipedia.Page.PageTest do
 
       assert {:error, _} = Page.fetch(12_345, http_client: http_client)
     end
-
-    # test ":error when non integer id is supplied" do
-    #   assert {:error, _} = Page.fetch("blah", [])
-    # end
 
     test ":error when unable to find body key" do
       http_client =


### PR DESCRIPTION
- Splits `build_url` into find by `pageid` and `page`.
- Removes `:by`  from previous iteration
- Opens up language removing pattern match of 2 chars
- Updates tests